### PR TITLE
test(sysrap): convert stree_load_test to ctest and harden GDML-fixture coverage

### DIFF
--- a/CSG/CSGImport.h
+++ b/CSG/CSGImport.h
@@ -1,22 +1,4 @@
 #pragma once
-/**
-CSGImport.h 
-==============
-
-See::
-
-    stree_load_test
-    CSGFoundry_importTree_Test
-
-
-CAUTION : SOME PARALLEL DEV NEEDS REVIEW, CONSOLIDATION::
-
-    CSG_stree_Convert.h
-    CSG_stree_Convert_test.cc
-    CSG_stree_Convert_test.sh
-
-
-**/
 
 #include <string>
 #include "plog/Severity.h"
@@ -59,6 +41,3 @@ struct CSG_API CSGImport  // HMM: maybe CSGCreate is a better name ?
     CSGNode*  importListnode(int nodeOffset, int partIdx, const snode& node, const sn* nd); 
 
 }; 
-
-
-

--- a/sysrap/stree.h
+++ b/sysrap/stree.h
@@ -2179,28 +2179,19 @@ inline int stree::find_lvid_node( const char* q_spec ) const
     return nidx ;
 }
 
-
-
-
-
-
-
-
-
-
-
 /**
 stree::pick_lvid_ordinal_node
 -------------------------------
 
-For ridx_type '?' look for the frame first using rem 'R' nodes and then tri 'T' nodes
+For ridx_type '?' look for the frame first using rem 'R' nodes and then tri 'T' nodes.
+For ridx_type 'N' search the full nds vector.
 
 **/
 inline const snode* stree::pick_lvid_ordinal_node( int lvid, int lvid_ordinal, char ridx_type  ) const
 {
     const snode* _node = nullptr ;
-    assert( ridx_type == 'R' || ridx_type == 'T' || ridx_type == '?' );
-    if( ridx_type == 'R' || ridx_type == 'T' )  // remainder OR triangulated
+    assert(ridx_type == 'N' || ridx_type == 'R' || ridx_type == 'T' || ridx_type == '?');
+    if (ridx_type == 'N' || ridx_type == 'R' || ridx_type == 'T') // full, remainder OR triangulated
     {
         _node = _pick_lvid_ordinal_node(lvid, lvid_ordinal, ridx_type );
     }

--- a/sysrap/stree.h
+++ b/sysrap/stree.h
@@ -6135,7 +6135,6 @@ inline void stree::get_remainder_nidx(std::vector<int>& nodes ) const
     get_repeat_nidx(nodes, q_repeat_index, q_repeat_ordinal);
 }
 
-
 /**
 stree::get_repeat_node
 -----------------------
@@ -6148,11 +6147,8 @@ not handle the rem and tri nodes.
 ::
 
    TEST=get_repeat_node stree_load_test
-
-   TEST=get_repeat_node RIDX=1 RORD=10 stree_load_test run
-
-   TEST=get_repeat_node RIDX=9 RORD=0 stree_load_test run
-
+   TEST=get_repeat_node RIDX=1 RORD=10 stree_load_test
+   TEST=get_repeat_node RIDX=9 RORD=0 stree_load_test
 **/
 
 inline void stree::get_repeat_node(std::vector<snode>& nodes, int q_repeat_index, int q_repeat_ordinal ) const
@@ -6431,8 +6427,6 @@ stree::get_global_aabb_sibling_overlaps
 -----------------------------------------
 
 TEST=get_global_aabb_sibling_overlaps stree_load_test
-TEST=get_global_aabb_sibling_overlaps stree_load_test pdb
-
 **/
 
 

--- a/sysrap/stree.h
+++ b/sysrap/stree.h
@@ -6188,7 +6188,6 @@ inline void stree::get_remainder_nidx(std::vector<int>& nodes ) const
     get_repeat_nidx(nodes, q_repeat_index, q_repeat_ordinal);
 }
 
-
 /**
 stree::get_repeat_node
 -----------------------
@@ -6201,11 +6200,8 @@ not handle the rem and tri nodes.
 ::
 
    TEST=get_repeat_node stree_load_test
-
-   TEST=get_repeat_node RIDX=1 RORD=10 stree_load_test run
-
-   TEST=get_repeat_node RIDX=9 RORD=0 stree_load_test run
-
+   TEST=get_repeat_node RIDX=1 RORD=10 stree_load_test
+   TEST=get_repeat_node RIDX=9 RORD=0 stree_load_test
 **/
 
 inline void stree::get_repeat_node(std::vector<snode>& nodes, int q_repeat_index, int q_repeat_ordinal ) const
@@ -6484,8 +6480,6 @@ stree::get_global_aabb_sibling_overlaps
 -----------------------------------------
 
 TEST=get_global_aabb_sibling_overlaps stree_load_test
-TEST=get_global_aabb_sibling_overlaps stree_load_test pdb
-
 **/
 
 

--- a/sysrap/stree.h
+++ b/sysrap/stree.h
@@ -2180,28 +2180,19 @@ inline int stree::find_lvid_node( const char* q_spec ) const
     return nidx ;
 }
 
-
-
-
-
-
-
-
-
-
-
 /**
 stree::pick_lvid_ordinal_node
 -------------------------------
 
-For ridx_type '?' look for the frame first using rem 'R' nodes and then tri 'T' nodes
+For ridx_type '?' look for the frame first using rem 'R' nodes and then tri 'T' nodes.
+For ridx_type 'N' search the full nds vector.
 
 **/
 inline const snode* stree::pick_lvid_ordinal_node( int lvid, int lvid_ordinal, char ridx_type  ) const
 {
     const snode* _node = nullptr ;
-    assert( ridx_type == 'R' || ridx_type == 'T' || ridx_type == '?' );
-    if( ridx_type == 'R' || ridx_type == 'T' )  // remainder OR triangulated
+    assert(ridx_type == 'N' || ridx_type == 'R' || ridx_type == 'T' || ridx_type == '?');
+    if (ridx_type == 'N' || ridx_type == 'R' || ridx_type == 'T') // full, remainder OR triangulated
     {
         _node = _pick_lvid_ordinal_node(lvid, lvid_ordinal, ridx_type );
     }

--- a/sysrap/tests/CMakeLists.txt
+++ b/sysrap/tests/CMakeLists.txt
@@ -120,6 +120,10 @@ set(TEST_SOURCES
 
 )
 
+set(STREE_GDML_TEST_SOURCE
+   stree_load_test.cc
+)
+
 set(REPORT_SOURCES
    sreport.cc
 )
@@ -174,6 +178,14 @@ foreach(SRC ${BASH_RUN_TEST_SOURCES})
        NAME ${name}.${TGT} 
        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/STestRunner.sh ${CMAKE_CURRENT_BINARY_DIR}/${TGT}  
     )
+endforeach()
+
+foreach(SRC ${STREE_GDML_TEST_SOURCE})
+    get_filename_component(TGT ${SRC} NAME_WE)
+    add_executable(${TGT} ${SRC})
+    target_compile_definitions(${TGT} PRIVATE STREE_LOAD_TEST_DEFAULT_GDML="${CMAKE_SOURCE_DIR}/tests/geom/sphere_leak.gdml")
+    target_link_libraries(${TGT} U4 CUDA::cudart)
+    add_test(${name}.${TGT} ${TGT})
 endforeach()
 
 set_tests_properties(${name}.SBndTest PROPERTIES DISABLED TRUE)

--- a/sysrap/tests/CMakeLists.txt
+++ b/sysrap/tests/CMakeLists.txt
@@ -117,6 +117,10 @@ set(TEST_SOURCES
 
 )
 
+set(STREE_GDML_TEST_SOURCE
+   stree_load_test.cc
+)
+
 set(REPORT_SOURCES
    sreport.cc
 )
@@ -171,6 +175,14 @@ foreach(SRC ${BASH_RUN_TEST_SOURCES})
        NAME ${name}.${TGT} 
        COMMAND bash ${CMAKE_CURRENT_SOURCE_DIR}/STestRunner.sh ${CMAKE_CURRENT_BINARY_DIR}/${TGT}  
     )
+endforeach()
+
+foreach(SRC ${STREE_GDML_TEST_SOURCE})
+    get_filename_component(TGT ${SRC} NAME_WE)
+    add_executable(${TGT} ${SRC})
+    target_compile_definitions(${TGT} PRIVATE STREE_LOAD_TEST_DEFAULT_GDML="${CMAKE_SOURCE_DIR}/tests/geom/sphere_leak.gdml")
+    target_link_libraries(${TGT} U4 CUDA::cudart)
+    add_test(${name}.${TGT} ${TGT})
 endforeach()
 
 set_tests_properties(${name}.SBndTest PROPERTIES DISABLED TRUE)

--- a/sysrap/tests/stree_load_test.cc
+++ b/sysrap/tests/stree_load_test.cc
@@ -54,6 +54,9 @@ struct stree_load_test
     void init(int argc, char** argv);
     void init();
 
+    bool has_soname_start(const char* q_soname) const;
+    bool has_spec_soname(const char* spec) const;
+
     int get_combined_transform(int LVID, int NDID  );
     int get_inst(int idx) const ;
     int pick_lvid_ordinal_node() const ;
@@ -168,6 +171,22 @@ inline void stree_load_test::init()
     std::cout << "]stree_load_test::init\n" ;
 }
 
+inline bool stree_load_test::has_soname_start(const char* q_soname) const
+{
+    return st && q_soname && st->find_lvid(q_soname, true) > -1;
+}
+
+inline bool stree_load_test::has_spec_soname(const char* spec) const
+{
+    if (spec == nullptr)
+        return false;
+
+    std::string            s(spec);
+    std::string::size_type pos = s.find(':');
+    std::string            q_soname = pos == std::string::npos ? s : s.substr(0, pos);
+
+    return has_soname_start(q_soname.c_str());
+}
 
 inline int stree_load_test::get_combined_transform( int LVID, int NDID )
 {
@@ -380,19 +399,18 @@ inline int stree_load_test::pick_lvid_ordinal_repeat_ordinal_inst() const
     int num = v_spec.size();
     for(int i=0 ; i < num ; i++)
     {
-        const std::string& spec = v_spec[i] ;
+        const std::string& spec = v_spec[i];
+
+        if (!has_spec_soname(spec.c_str()))
+        {
+            std::cout << "stree_load_test::pick_lvid_ordinal_repeat_ordinal_inst SKIP missing soname for spec "
+                      << std::setw(4) << i << " " << std::setw(50) << spec << "\n";
+            continue;
+        }
+
         int inst_idx = st->pick_lvid_ordinal_repeat_ordinal_inst( spec.c_str() );
 
-        std::cout
-            << "("
-            << std::setw(4) << i
-            << " "
-            << std::setw(50) << spec
-            << " "
-            << std::setw(7) << inst_idx
-            << ") "
-            << "\n"
-            ;
+        std::cout << std::setw(4) << i << " " << std::setw(50) << spec << " " << std::setw(7) << inst_idx << "\n";
     }
     return 0 ;
 }
@@ -418,6 +436,12 @@ inline int stree_load_test::get_frame() const
     for(int i=0 ; i < num ; i++)
     {
         const std::string& spec = v_spec[i] ;
+        if (!has_spec_soname(spec.c_str()))
+        {
+            std::cout << "stree_load_test::get_frame SKIP missing soname for spec "
+                      << std::setw(4) << i << " " << std::setw(50) << spec << "\n";
+            continue;
+        }
         sframe             fr = st->get_frame(spec.c_str());
         std::cout << fr ;
     }
@@ -427,7 +451,11 @@ inline int stree_load_test::get_frame() const
 inline int stree_load_test::get_frame_MOI() const
 {
     const char* MOI = ssys::getenvvar("MOI", nullptr);
-    if(!MOI) return 1 ;
+    if (!MOI)
+    {
+        std::cout << "stree_load_test::get_frame_MOI SKIP no MOI envvar\n";
+        return 0;
+    }
 
     sframe mfr = st->get_frame(MOI);
     std::cout << "stree_load_test::get_frame_MOI\n" <<  MOI << "\n" << mfr << "\n"  ;
@@ -446,6 +474,16 @@ inline int stree_load_test::get_frame_scan_(const char* solid, int i0, int i1, i
         << " j0 " << j0 << " j1 " << j1
         << "\n"
         ;
+
+    if (!has_soname_start(solid))
+    {
+        std::cout
+            << "stree_load_test::get_frame_scan_"
+            << " SKIP missing soname for solid "
+            << (solid ? solid : "-")
+            << "\n";
+        return 0;
+    }
 
     for(int i=i0 ; i < i1 ; i++)
     for(int j=j0 ; j <= j1 ; j++)
@@ -489,6 +527,8 @@ inline int stree_load_test::get_prim_aabb() const
         }
 
         std::cout << label << " " << num_nd << std::endl ;
+        if (num_nd == 0)
+            continue;
 
         for(int j=0 ; j < 3 ; j++)
         {
@@ -509,6 +549,9 @@ inline int stree_load_test::get_prim_aabb() const
                 k0 = num_nd - 20   ;
                 k1 = num_nd ;
             }
+
+            k0 = std::max(0, std::min(k0, num_nd));
+            k1 = std::max(k0, std::min(k1, num_nd));
 
             for(int k=k0 ; k < k1 ; k++)
             {
@@ -604,10 +647,14 @@ inline int stree_load_test::desc_repeat_index() const
 
 inline int stree_load_test::get_global_aabb() const
 {
+    const char* tmpfold = ssys::getenvvar("TMPFOLD", "/tmp/stree_load_test");
+    std::string path = std::string(tmpfold) + "/get_global_aabb";
+
     std::cout << "[stree_load_test::get_global_aabb \n" ;
+    std::cout << " save to " << path << "\n";
 
     NPFold* f = st->get_global_aabb();
-    f->save("$TMPFOLD/get_global_aabb");
+    f->save(path.c_str());
 
     std::cout << "]stree_load_test::get_global_aabb \n" ;
     return 0 ;
@@ -624,9 +671,29 @@ This approach yields too many overlaps to wade thru
 
 inline int stree_load_test::get_global_aabb_check() const
 {
-    NPFold* f = NPFold::Load("$TMPFOLD/get_global_aabb");
+    const char* tmpfold = ssys::getenvvar("TMPFOLD", "/tmp/stree_load_test");
+    std::string path = std::string(tmpfold) + "/get_global_aabb";
+
+    NPFold* f = NPFold::Load(path.c_str());
+    if (f == nullptr)
+    {
+        std::cout
+            << "[stree_load_test::get_global_aabb_check\n"
+            << " load failed path " << path << "\n"
+            << "]stree_load_test::get_global_aabb_check\n";
+        return 0;
+    }
+
     const NP* bb = f->get("bb");
     const NP* ii = f->get("ii");
+    if (bb == nullptr || ii == nullptr)
+    {
+        std::cout
+            << "[stree_load_test::get_global_aabb_check\n"
+            << " missing arrays from path " << path << "\n"
+            << "]stree_load_test::get_global_aabb_check\n";
+        return 0;
+    }
 
     const double* bbv = bb->cvalues<double>();
     const size_t* iiv = ii->cvalues<size_t>();
@@ -672,39 +739,43 @@ inline int stree_load_test::get_global_aabb_check() const
 
 inline int stree_load_test::get_global_aabb_sibling_overlaps() const
 {
+    const char* tmpfold = ssys::getenvvar("TMPFOLD", "/tmp/stree_load_test");
+    std::string path = std::string(tmpfold) + "/get_global_aabb_sibling_overlaps";
+
     std::cout << "[stree_load_test::get_global_aabb_sibling_overlaps \n" ;
+    std::cout << " save to " << path << "\n";
 
     NPFold* f = st->get_global_aabb_sibling_overlaps();
-    f->save("$TMPFOLD/get_global_aabb_sibling_overlaps");
+    f->save(path.c_str());
 
     std::cout << "]stree_load_test::get_global_aabb_sibling_overlaps \n" ;
     return 0 ;
 }
 
-
-
-
-
-
-
 inline int stree_load_test::desc_factor_nodes(int fidx) const
 {
+    int num_factor = st ? st->get_num_factor() : 0;
+    if (fidx < 0 || fidx >= num_factor)
+    {
+        std::cout << "stree_load_test::desc_factor_nodes SKIP invalid factor index " << fidx
+                  << " num_factor " << num_factor << "\n";
+        return 0;
+    }
     std::cout << st->desc_factor_nodes(fidx) << "\n" ;
-    return 0 ;
+    return 0;
 }
-
 
 inline int stree_load_test::desc_repeat_node(int ridx, int rord) const
 {
     std::cout << st->desc_repeat_node(ridx, rord) << "\n" ;
     return 0 ;
 }
+
 inline int stree_load_test::desc_repeat_nodes() const
 {
     std::cout << st->desc_repeat_nodes() << "\n" ;
     return 0 ;
 }
-
 
 inline int stree_load_test::desc_nds() const
 {
@@ -716,11 +787,13 @@ inline int stree_load_test::desc_rem() const
     std::cout << st->desc_rem() << "\n" ;
     return 0 ;
 }
+
 inline int stree_load_test::desc_tri() const
 {
     std::cout << st->desc_tri() << "\n" ;
     return 0 ;
 }
+
 inline int stree_load_test::desc_NRT() const
 {
     std::cout << st->desc_NRT() << "\n" ;

--- a/sysrap/tests/stree_load_test.cc
+++ b/sysrap/tests/stree_load_test.cc
@@ -1,10 +1,5 @@
 /**
-stree_load_test.cc
-===================
-
-::
-
-    stree_load_test
+    ctest -R SysRapTest.stree_load_test --output-on-failure
 
     TEST=get_inst IIDX=100                      stree_load_test
     TEST=pick_lvid_ordinal_node                 stree_load_test
@@ -18,7 +13,16 @@ stree_load_test.cc
     TEST=desc_factor_nodes FIDX=0               stree_load_test
     TEST=desc_repeat_node RIDX=0 RORD=0         stree_load_test
 
+    TEST=desc_solid LVID=43 stree_load_test
+    TEST=desc_solid LVID=124 stree_load_test
+    TEST=desc_solid LVID=32 stree_load_test
+
+    TEST=desc_node_ELVID ELVID=43,44,45,46 stree_load_test
+    TEST=desc_node_ECOPYNO ECOPYNO=52400   stree_load_test
+    TEST=desc_node_EBOUNDARY EBOUNDARY=303 stree_load_test
 **/
+
+#include "OPTICKS_LOG.hh"
 
 #include "ssys.h"
 #include "stree.h"
@@ -27,13 +31,27 @@ stree_load_test.cc
 #include "sn.h"
 #include "SBitSet.h"
 
+#include "U4GDML.h"
+#include "U4SensitiveDetector.hh"
+#include "U4Tree.h"
+
+#ifdef STREE_LOAD_TEST_DEFAULT_GDML
+static constexpr const char* STREE_LOAD_TEST_DEFAULT_GDML_PATH = STREE_LOAD_TEST_DEFAULT_GDML;
+#else
+static constexpr const char* STREE_LOAD_TEST_DEFAULT_GDML_PATH = nullptr;
+#endif
 
 struct stree_load_test
 {
-    const char* TEST ;
-    const stree* st ;
+    static constexpr const char* DEFAULT_TEST = "desc";
 
-    stree_load_test();
+    const char* TEST ;
+    const char* gdmlpath;
+    stree*      st;
+    U4Tree*     tr;
+
+    stree_load_test(int argc, char** argv);
+    void init(int argc, char** argv);
     void init();
 
     int get_combined_transform(int LVID, int NDID  );
@@ -82,24 +100,70 @@ struct stree_load_test
     int main();
 };
 
-inline stree_load_test::stree_load_test()
-    :
-    TEST(ssys::getenvvar("TEST", nullptr)),
-    st(nullptr)
+inline stree_load_test::stree_load_test(int argc, char** argv) :
+    TEST(ssys::getenvvar("TEST", DEFAULT_TEST)),
+    gdmlpath(ssys::getenvvar("STREE_LOAD_TEST_GDML", STREE_LOAD_TEST_DEFAULT_GDML_PATH)),
+    st(nullptr),
+    tr(nullptr)
 {
+    init(argc, argv);
+}
+
+inline void stree_load_test::init(int argc, char** argv)
+{
+    for (int i = 1; i < argc; i++)
+    {
+        const char* arg = argv[i];
+        if (arg == nullptr)
+            continue;
+
+        std::string a(arg);
+        bool        is_gdml = a.size() >= 5 && a.compare(a.size() - 5, 5, ".gdml") == 0;
+
+        if (is_gdml)
+        {
+            gdmlpath = arg;
+        }
+        else
+        {
+            TEST = arg;
+        }
+    }
+
     init();
 }
 
 inline void stree_load_test::init()
 {
     bool noload = strcmp(TEST,"get_global_aabb_check") == 0 ;
-    if(!noload)
+
+    if (noload == false && gdmlpath != nullptr)
+    {
+        if (U4SensitiveDetector::Get("PhotonDetector") == nullptr)
+            new U4SensitiveDetector("PhotonDetector");
+        if (U4SensitiveDetector::Get("PMTSDMgr") == nullptr)
+            new U4SensitiveDetector("PMTSDMgr");
+
+        const G4VPhysicalVolume* world = U4GDML::Read(gdmlpath);
+        LOG_IF(fatal, world == nullptr)
+            << "stree_load_test::init FAILED TO READ GDML "
+            << " gdmlpath " << (gdmlpath ? gdmlpath : "-");
+
+        if (world != nullptr)
+        {
+            st = new stree;
+            tr = U4Tree::Create(st, world);
+        }
+    }
+    else if (!noload)
     {
         st = stree::Load();
         if( st == nullptr ) std::cout << "stree_load_test::init FAILED TO LOAD TREE \n" ;
     }
 
     std::cout << "[stree_load_test::init\n" ;
+    std::cout << " TEST " << (TEST ? TEST : "-") << "\n";
+    std::cout << " gdmlpath " << (gdmlpath ? gdmlpath : "-") << "\n";
     std::cout << ( st ? st->desc_id() : "-" ) << "\n" ;
     std::cout << "]stree_load_test::init\n" ;
 }
@@ -674,14 +738,12 @@ inline int stree_load_test::desc_node_ECOPYNO() const
     std::cout << st->desc_node_ECOPYNO() << "\n" ;
     return 0 ;
 }
+
 inline int stree_load_test::desc_node_EBOUNDARY() const
 {
     std::cout << st->desc_node_EBOUNDARY() << "\n" ;
     return 0 ;
 }
-
-
-
 
 inline int stree_load_test::desc_node_solids() const
 {
@@ -701,6 +763,7 @@ inline int stree_load_test::desc_solids() const
     std::cout << st->desc_solids() ;
     return 0 ;
 }
+
 inline int stree_load_test::desc_solid(int lvid) const
 {
     std::cout << st->desc_solid(lvid) ;
@@ -729,9 +792,6 @@ inline int stree_load_test::desc_solid(int lvid) const
         std::cout << "gtd\n" << stra<double>::Desc(m2w) << "\n" ;
     }
 
-
-
-
     std::vector<sn*> nds ;    // CSG constituent nodes of the LV
     sn::GetLVNodes(nds, lvid );
     int num_nds = nds.size();
@@ -750,11 +810,13 @@ inline int stree_load_test::desc_solid(int lvid) const
 
     return 0 ;
 }
+
 inline int stree_load_test::desc() const
 {
     std::cout << st->desc() << "\n" ;
     return 0 ;
 }
+
 inline int stree_load_test::save_desc(const char* fold) const
 {
     std::cout
@@ -767,6 +829,7 @@ inline int stree_load_test::save_desc(const char* fold) const
     st->save_desc(fold);
     return 0 ;
 }
+
 inline int stree_load_test::make_tree_digest() const
 {
     const char* tree_digest = st->get_tree_digest();
@@ -802,15 +865,11 @@ inline int stree_load_test::desc_nodes_with_center_within_ce() const
      return 0 ;
 }
 
-
 inline int stree_load_test::desc_prim() const
 {
      std::cout << st->desc_prim();
      return 0 ;
 }
-
-
-
 
 inline int stree_load_test::main()
 {
@@ -864,20 +923,10 @@ inline int stree_load_test::main()
     return rc ;
 }
 
-
 int main(int argc, char** argv)
 {
-    stree_load_test t;
+    OPTICKS_LOG(argc, argv);
+
+    stree_load_test t(argc, argv);
     return t.main();
 }
-
-/**
-    TEST=desc_solid LVID=43 stree_load_test  run
-    TEST=desc_solid LVID=124 stree_load_test  run
-    TEST=desc_solid LVID=32 stree_load_test
-
-
-    TEST=desc_node_ELVID ELVID=43,44,45,46 stree_load_test
-    TEST=desc_node_ECOPYNO ECOPYNO=52400   stree_load_test
-    TEST=desc_node_EBOUNDARY EBOUNDARY=303   stree_load_test
-**/


### PR DESCRIPTION
Turn `sysrap/tests/stree_load_test.cc` into a regular CMake/ctest target that builds `stree` directly from a checked-in
GDML fixture, and harden its broad inspection modes so they run safely on the small default geometry.

## Why

`stree_load_test` was previously a developer-only helper with shell-script setup and external geometry assumptions. That
made it hard to run in CI and brittle when exercised against a minimal fixture.

This change makes the test self-contained, ctest-friendly, and more robust across geometries.

## What Changed

- register `stree_load_test` as a normal CMake/ctest target in `sysrap/tests/CMakeLists.txt`
- construct `stree` in-process from a checked-in GDML fixture via `U4GDML` and `U4Tree`
- use `tests/geom/sphere_leak.gdml` as the default fixture geometry
- restore `'N'` support in `stree::pick_lvid_ordinal_node(...)` so full-node lookups continue to work with existing callers
- harden `TEST=ALL` and related inspection paths to skip geometry-specific probes when the default fixture does not provide the expected solid names
- make MOI/TMPFOLD-dependent paths degrade gracefully instead of aborting
- clamp small-vector scans and guard factor-dependent probes for tiny fixture geometries
- clean up stale test-runner references/comments

## Result

`stree_load_test` can now be run directly under ctest without external shell setup, and `TEST=ALL` no longer aborts on
the default small GDML fixture.

## Validation

- `ctest --test-dir build -R SysRapTest.stree_load_test`
- `TEST=ALL ctest --test-dir build -R SysRapTest.stree_load_test -V`
