### PR TITLE
synrad example: build usage requirements; document persisted-geometry resolution

### DIFF
--- a/docs/inputs-outputs.md
+++ b/docs/inputs-outputs.md
@@ -31,6 +31,24 @@ See [Physics](physics.md) for the current standard-GPU interpretation of GDML
 optical-surface properties such as `model`, `finish`, `type`, `EFFICIENCY`,
 and `REFLECTIVITY`.
 
+### Persisted CSGFoundry geometry
+
+Service-style applications (consumers of `CSGOptiXService`) load a persisted
+CSGFoundry geometry directory instead of importing GDML. Resolution is by an
+environment variable pair, implemented in `spath::CFBaseFromGEOM`:
+
+```bash
+export GEOM=<name>
+export <name>_CFBaseFromGEOM=/path/to/base   # directory containing CSGFoundry/
+```
+
+Both variables are required: `GEOM` names the geometry, and the variable
+named `<name>_CFBaseFromGEOM` — the literal geometry name followed by
+`_CFBaseFromGEOM` — carries its base directory. Setting `CFBASE` alone does
+not resolve geometry on this path. A persisted geometry is produced from a
+Geant4-integrated run with `G4CXOpticks__setGeometry_saveGeometry` pointing
+at the base directory to be written.
+
 ## Photon source inputs
 
 Simphony examples feed the GPU simulation in three common ways:

--- a/examples/synrad/CMakeLists.txt
+++ b/examples/synrad/CMakeLists.txt
@@ -25,11 +25,17 @@ target_link_libraries(synrad
 # (sysrap NP/sphoton, the qudarap Cu table), so take the include directories
 # from the imported targets without linking their libraries. sphoton.h sits
 # on the CUDA vector types, so the CUDA headers are needed at compile time.
+# The header chain also needs glm (stra.h uses gtx extensions, gated behind
+# GLM_ENABLE_EXPERIMENTAL) and plog (OpticksPhoton.hh); both are header-only
+# INTERFACE targets, so linking them propagates includes without libraries —
+# required wherever they are not on default compiler paths.
+find_package(plog REQUIRED)
 find_package(CUDAToolkit REQUIRED)
 add_executable(synrad_g4 synrad_g4.cpp)
 get_target_property(_sysrap_inc  simphony::SysRap  INTERFACE_INCLUDE_DIRECTORIES)
 get_target_property(_qudarap_inc simphony::QUDARap INTERFACE_INCLUDE_DIRECTORIES)
 target_include_directories(synrad_g4 PRIVATE ${_sysrap_inc} ${_qudarap_inc} ${CUDAToolkit_INCLUDE_DIRS})
-target_link_libraries(synrad_g4 ${Geant4_LIBRARIES})
+target_link_libraries(synrad_g4 ${Geant4_LIBRARIES} glm::glm plog::plog)
+target_compile_definitions(synrad_g4 PRIVATE GLM_ENABLE_EXPERIMENTAL)
 
 install(TARGETS synrad synrad_g4)


### PR DESCRIPTION
Two small fixes from the swf-epicprod worker integration (spack-based eic_dev_cuda container), companions to #438.

- **examples/synrad CMake**: `synrad_g4` takes include directories from the imported simphony targets without linking their libraries, so it never inherits usage requirements — glm, plog, and `GLM_ENABLE_EXPERIMENTAL` (needed by the `sphoton.h` → `stra.h` / `OpticksPhoton.hh` chain) arrive only where those packages sit on default compiler paths. The fix links the header-only `glm::glm` and `plog::plog` INTERFACE targets (includes propagate, no libraries linked, preserving the header-only design) and declares the definition on the target. Verified in the container: the example configures and builds against a branch install with no flag injection, where it previously required `-I<glm> -I<plog> -DGLM_ENABLE_EXPERIMENTAL` via `CMAKE_CXX_FLAGS`.

- **docs/inputs-outputs.md**: document persisted CSGFoundry geometry resolution — the `GEOM=<name>` plus `<name>_CFBaseFromGEOM=<base>` environment variable pair read by `spath::CFBaseFromGEOM`. `CFBASE` alone does not resolve geometry on this path, and the requirement was previously undocumented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8ikLGuXqZW26wXi8RCkrf