### PR TITLE
feat(u4): add tessellated-solid conversion support

### DIFF
--- a/docs/inputs-outputs.md
+++ b/docs/inputs-outputs.md
@@ -31,6 +31,19 @@ See [Physics](physics.md) for the current standard-GPU interpretation of GDML
 optical-surface properties such as `model`, `finish`, `type`, `EFFICIENCY`,
 and `REFLECTIVITY`.
 
+### Analytic and tessellated geometry
+
+GDML can provide native `<tessellated>` solids, but triangle geometry does not
+have to originate in that form. Simphony automatically selects native
+tessellated solids, including tessellated constituents inside Boolean,
+displaced, or multi-union solids. Other Geant4 solids can be selected
+automatically or by exact solid name with `stree__force_triangulate_solid`.
+
+Triangulation selection and mesh resolution are persisted in the generated
+geometry cache, so configure them before generating the cache. If a selected
+solid is repeated, its placements remain in global triangle geometry rather
+than an analytic instance factor, which can increase memory use.
+
 ## Photon source inputs
 
 Simphony examples feed the GPU simulation in three common ways:

--- a/sysrap/sn.h
+++ b/sysrap/sn.h
@@ -416,6 +416,8 @@ struct SYSRAP_API sn
     void setXF(     const glm::tmat4x4<double>& t, const glm::tmat4x4<double>& v ) ;
     void combineXF( const glm::tmat4x4<double>& t );
     void combineXF( const glm::tmat4x4<double>& t, const glm::tmat4x4<double>& v ) ;
+    void prependXF(const glm::tmat4x4<double>& t);
+    void prependXF(const glm::tmat4x4<double>& t, const glm::tmat4x4<double>& v);
     std::string descXF() const ;
 
     static sn* Cylinder(double radius, double z1, double z2) ;
@@ -2760,6 +2762,44 @@ inline void sn::combineXF( const glm::tmat4x4<double>& t, const glm::tmat4x4<dou
         glm::tmat4x4<double> vv = v * xform->v ;
         xform->t = tt ;
         xform->v = vv ;
+    }
+}
+
+/**
+ * Prepends an enclosing transform to the node transform.
+ *
+ * With column vectors, an enclosing placement must multiply the existing
+ * transform from the left. The inverse transforms are multiplied in the
+ * opposite order.
+ *
+ * @param t forward enclosing transform
+ */
+
+inline void sn::prependXF(const glm::tmat4x4<double>& t)
+{
+    glm::tmat4x4<double> v = glm::inverse(t);
+    prependXF(t, v);
+}
+
+/**
+ * Prepends enclosing forward and inverse transforms to the node transform.
+ *
+ * @param t forward enclosing transform
+ * @param v inverse enclosing transform
+ */
+
+inline void sn::prependXF(const glm::tmat4x4<double>& t, const glm::tmat4x4<double>& v)
+{
+    if (xform == nullptr)
+    {
+        setXF(t, v);
+    }
+    else
+    {
+        glm::tmat4x4<double> tt = t * xform->t;
+        glm::tmat4x4<double> vv = xform->v * v;
+        xform->t = tt;
+        xform->v = vv;
     }
 }
 

--- a/sysrap/stree.h
+++ b/sysrap/stree.h
@@ -716,7 +716,7 @@ struct stree
     bool        is_triangulate(int lvid) const ;  // OR of the above
 
     void classifySubtrees();
-    bool subtree_contains_triangulated(const char* sub) const ;
+    bool subtree_contains_triangulated(const char* sub) const;
     void disqualifyTriangulatedRepeats();
     bool is_contained_repeat(const char* sub) const ;
     void disqualifyContainedRepeats();
@@ -5218,7 +5218,6 @@ inline void stree::classifySubtrees()
     if(level>0) std::cout << "] stree::classifySubtrees " << std::endl ;
 }
 
-
 /**
  * Returns whether the first instance of a subtree contains a logical volume
  * selected for triangulation.
@@ -5231,13 +5230,15 @@ inline bool stree::subtree_contains_triangulated(const char* sub) const
     int nidx = get_first(sub);
     assert(nidx > -1);
 
-    if (is_triangulate(nds[nidx].lvid)) return true;
+    if (is_triangulate(nds[nidx].lvid))
+        return true;
 
     std::vector<int> progeny;
     get_progeny(progeny, nidx);
 
     for (unsigned i = 0; i < progeny.size(); ++i)
-        if (is_triangulate(nds[progeny[i]].lvid)) return true;
+        if (is_triangulate(nds[progeny[i]].lvid))
+            return true;
 
     return false;
 }
@@ -5251,20 +5252,21 @@ inline bool stree::subtree_contains_triangulated(const char* sub) const
  */
 inline void stree::disqualifyTriangulatedRepeats()
 {
-    unsigned num = subs_freq->get_num();
+    unsigned                 num = subs_freq->get_num();
     std::vector<std::string> disqualify;
 
     for (unsigned i = 0; i < num; ++i)
     {
         const char* sub = subs_freq->get_key(i);
-        int freq = subs_freq->get_freq(i);
-        if (freq < FREQ_CUT) continue;
-        if (subtree_contains_triangulated(sub)) disqualify.push_back(sub);
+        int         freq = subs_freq->get_freq(i);
+        if (freq < FREQ_CUT)
+            continue;
+        if (subtree_contains_triangulated(sub))
+            disqualify.push_back(sub);
     }
 
     subs_freq->set_disqualify(disqualify);
 }
-
 
 /**
 stree::is_contained_repeat
@@ -5699,8 +5701,6 @@ inline std::string stree::descNodes() const
     std::string str = ss.str();
     return str ;
 }
-
-
 
 /**
 stree::factorize

--- a/sysrap/stree.h
+++ b/sysrap/stree.h
@@ -715,8 +715,9 @@ struct stree
     bool        is_auto_triangulate( int lvid ) const ;  // WIP: automate decision, avoiding hassle with geometry updates that change/add solid names
     bool        is_triangulate(int lvid) const ;  // OR of the above
 
-
     void classifySubtrees();
+    bool subtree_contains_triangulated(const char* sub) const ;
+    void disqualifyTriangulatedRepeats();
     bool is_contained_repeat(const char* sub) const ;
     void disqualifyContainedRepeats();
     void sortSubtrees();
@@ -5219,6 +5220,53 @@ inline void stree::classifySubtrees()
 
 
 /**
+ * Returns whether the first instance of a subtree contains a logical volume
+ * selected for triangulation.
+ *
+ * Every instance represented by the same subtree digest has the same
+ * logical-volume structure.
+ */
+inline bool stree::subtree_contains_triangulated(const char* sub) const
+{
+    int nidx = get_first(sub);
+    assert(nidx > -1);
+
+    if (is_triangulate(nds[nidx].lvid)) return true;
+
+    std::vector<int> progeny;
+    get_progeny(progeny, nidx);
+
+    for (unsigned i = 0; i < progeny.size(); ++i)
+        if (is_triangulate(nds[progeny[i]].lvid)) return true;
+
+    return false;
+}
+
+/**
+ * Excludes repeated subtrees containing triangulated solids from factorization
+ * because triangulated factors are not supported.
+ *
+ * This check runs before contained-repeat disqualification so an analytic child
+ * without a triangulated solid can still become a factor.
+ */
+inline void stree::disqualifyTriangulatedRepeats()
+{
+    unsigned num = subs_freq->get_num();
+    std::vector<std::string> disqualify;
+
+    for (unsigned i = 0; i < num; ++i)
+    {
+        const char* sub = subs_freq->get_key(i);
+        int freq = subs_freq->get_freq(i);
+        if (freq < FREQ_CUT) continue;
+        if (subtree_contains_triangulated(sub)) disqualify.push_back(sub);
+    }
+
+    subs_freq->set_disqualify(disqualify);
+}
+
+
+/**
 stree::is_contained_repeat
 ----------------------------
 
@@ -5663,6 +5711,10 @@ Canonically invoked from U4Tree::Create
 classifySubtrees
    compute and store stree::subtree_digest for subtrees of all nodes using (sfreq*)subs_freq
 
+disqualifyTriangulatedRepeats
+   disqualify repeated subtrees containing triangulated solids because triangulated factors
+   are not supported
+
 disqualifyContainedRepeats
    flip freq sign in (sfreq*)subs_freq to disqualify all contained repeats, as want factors
    to have the largest subtrees
@@ -5678,8 +5730,8 @@ labelFactorSubtrees
    leaving remainder nodes at default of zero repeat_index
 
 findForceTriangulateLVID
-   populates force_triangulate_lvid vector of lvid int based on force_triangulate
-   envvar and solid names. The vector is used by stree::is_force_triangulate
+   before classifying repeats, populate force_triangulate_lvid from the configured
+   solid names. The vector is used by stree::is_force_triangulate
 
 collectGlobalNodes
    collect global non-instanced nodes into *rem* vector and depending on envvars collect
@@ -5692,13 +5744,14 @@ inline void stree::factorize()
 {
     if(level>0) std::cout << "[ stree::factorize (" << level << ")" << std::endl ;
 
+    findForceTriangulateLVID();
     classifySubtrees();
+    disqualifyTriangulatedRepeats();
     disqualifyContainedRepeats();
     sortSubtrees();
     enumerateFactors();
     labelFactorSubtrees();
 
-    findForceTriangulateLVID();
     collectGlobalNodes();
 
     if(level>0) std::cout << desc_factor() << std::endl ;

--- a/u4/U4Solid.h
+++ b/u4/U4Solid.h
@@ -776,7 +776,7 @@ inline void U4Solid::init_MultiUnion()
 
         sn* p = Convert( sub,  lvid, depth+1, level );
         assert(p);
-        p->combineXF(xf);
+        p->prependXF(xf);
         bool p_expect = p->is_primitive();
 
         if(level > 0 || !p_expect ) std::cout
@@ -1388,7 +1388,7 @@ inline void U4Solid::init_DisplacedSolid()
     if(!single_disp) std::raise(SIGINT);
 
     root = Convert( moved, lvid, depth+1, level );
-    root->combineXF(xf);
+    root->prependXF(xf);
 }
 
 

--- a/u4/U4Solid.h
+++ b/u4/U4Solid.h
@@ -23,9 +23,9 @@ npy/NNodeUncoincide npy/NNodeNudger
 
 **/
 
-
-#include <set>
 #include <csignal>
+#include <plog/Log.h>
+#include <set>
 
 #include "ssys.h"
 #include "scuda.h"
@@ -48,6 +48,7 @@ npy/NNodeUncoincide npy/NNodeNudger
 #include "G4Polycone.hh"
 #include "G4Sphere.hh"
 #include "G4SubtractionSolid.hh"
+#include "G4TessellatedSolid.hh"
 #include "G4Torus.hh"
 #include "G4Trap.hh"
 #include "G4Trd.hh"
@@ -81,7 +82,8 @@ enum {
     _G4DisplacedSolid,
     _G4CutTubs,
     _G4Trap,
-    _G4Trd
+    _G4Trd,
+    _G4TessellatedSolid
  };
 
 struct U4Solid
@@ -103,6 +105,7 @@ struct U4Solid
     static constexpr const char* G4CutTubs_           = "TuC" ;
     static constexpr const char* G4Trap_ = "Tra";
     static constexpr const char* G4Trd_ = "Trd";
+    static constexpr const char* G4TessellatedSolid_ = "Tes";
 
     static constexpr const char* _U4Solid__IsFlaggedLVID = "U4Solid__IsFlaggedLVID" ;
     static const int   IsFlaggedLVID_ ;
@@ -152,6 +155,7 @@ private:
     void init_CutTubs();
     void init_Trap();
     void init_Trd();
+    void init_Tessellated();
     void _setRoot_FromVertices(const double v[8][3]);
 
     sn* init_Sphere_(char layer);
@@ -306,6 +310,8 @@ inline int U4Solid::Type(const char* name)   // static
         type = _G4Trap;
     if (strcmp(name, "G4Trd") == 0)
         type = _G4Trd;
+    if (strcmp(name, "G4TessellatedSolid") == 0)
+        type = _G4TessellatedSolid;
     return type ;
 }
 
@@ -334,6 +340,9 @@ inline const char* U4Solid::Tag(int type)   // static
             break;
         case _G4Trd:
             tag = G4Trd_;
+            break;
+        case _G4TessellatedSolid:
+            tag = G4TessellatedSolid_;
             break;
         }
     return tag ;
@@ -437,6 +446,9 @@ inline void U4Solid::init_Constituents()
             break;
         case _G4Trd:
             init_Trd();
+            break;
+        case _G4TessellatedSolid:
+            init_Tessellated();
             break;
         }
 
@@ -910,6 +922,43 @@ inline void U4Solid::init_Trd()
     v[7][2] = +dz;
 
     _setRoot_FromVertices(v);
+}
+
+/**
+ * Creates an axis-aligned box placeholder for a tessellated solid.
+ *
+ * The placeholder preserves the solid's extent and boundary metadata, but not
+ * its facets. Configure the solid for triangulation with
+ * `stree__force_triangulate_solid`; `U4Mesh` then supplies the exact facets for
+ * GPU intersection.
+ */
+
+inline void U4Solid::init_Tessellated()
+{
+    const G4TessellatedSolid* tess = static_cast<const G4TessellatedSolid*>(solid);
+    assert(tess);
+
+    double x0 = tess->GetMinXExtent() / CLHEP::mm;
+    double x1 = tess->GetMaxXExtent() / CLHEP::mm;
+    double y0 = tess->GetMinYExtent() / CLHEP::mm;
+    double y1 = tess->GetMaxYExtent() / CLHEP::mm;
+    double z0 = tess->GetMinZExtent() / CLHEP::mm;
+    double z1 = tess->GetMaxZExtent() / CLHEP::mm;
+
+    root = sn::Box3(x1 - x0, y1 - y0, z1 - z0);
+
+    glm::tvec3<double> tla((x0 + x1) / 2., (y0 + y1) / 2., (z0 + z1) / 2.);
+    if (glm::length(tla) > 0.)
+    {
+        glm::tmat4x4<double> xf = glm::translate(glm::tmat4x4<double>(1.), tla);
+        root->combineXF(xf);
+    }
+
+    LOG(plog::warning)
+        << "U4Solid::init_Tessellated"
+        << " name " << (name ? name : "-")
+        << " facets " << tess->GetNumberOfFacets()
+        << " : analytic bbox placeholder only, list the solid in stree__force_triangulate_solid";
 }
 
 // Compute 6 outward face planes + AABB from 8 vertices, install as CSG_CONVEXPOLYHEDRON root.

--- a/u4/U4Solid.h
+++ b/u4/U4Solid.h
@@ -126,7 +126,7 @@ struct U4Solid
 
     static int          Type(const char* entityType ) ;
     static const char*  Tag( int type ) ;
-    static bool         ContainsTessellated(const G4VSolid* solid) ;
+    static bool ContainsTessellated(const G4VSolid* solid);
     const char* tag() const ;
 
 
@@ -359,11 +359,14 @@ inline const char* U4Solid::Tag(int type)   // static
 
 inline bool U4Solid::ContainsTessellated(const G4VSolid* solid) // static
 {
-    if (solid == nullptr) return false;
-    if (dynamic_cast<const G4TessellatedSolid*>(solid) != nullptr) return true;
+    if (solid == nullptr)
+        return false;
+    if (dynamic_cast<const G4TessellatedSolid*>(solid) != nullptr)
+        return true;
 
     const G4DisplacedSolid* displaced = dynamic_cast<const G4DisplacedSolid*>(solid);
-    if (displaced != nullptr) return ContainsTessellated(displaced->GetConstituentMovedSolid());
+    if (displaced != nullptr)
+        return ContainsTessellated(displaced->GetConstituentMovedSolid());
 
     const G4BooleanSolid* boolean = dynamic_cast<const G4BooleanSolid*>(solid);
     if (boolean != nullptr)
@@ -373,7 +376,8 @@ inline bool U4Solid::ContainsTessellated(const G4VSolid* solid) // static
     const G4MultiUnion* multi_union = dynamic_cast<const G4MultiUnion*>(solid);
     if (multi_union != nullptr)
         for (int i = 0; i < multi_union->GetNumberOfSolids(); ++i)
-            if (ContainsTessellated(multi_union->GetSolid(i))) return true;
+            if (ContainsTessellated(multi_union->GetSolid(i)))
+                return true;
 
     return false;
 }

--- a/u4/U4Solid.h
+++ b/u4/U4Solid.h
@@ -24,7 +24,6 @@ npy/NNodeUncoincide npy/NNodeNudger
 **/
 
 #include <csignal>
-#include <plog/Log.h>
 #include <set>
 
 #include "ssys.h"
@@ -56,6 +55,7 @@ npy/NNodeUncoincide npy/NNodeNudger
 #include "G4UnionSolid.hh"
 
 #include "G4BooleanSolid.hh"
+#include "G4DisplacedSolid.hh"
 #include "G4RotationMatrix.hh"
 #include <CLHEP/Units/SystemOfUnits.h>
 
@@ -126,6 +126,7 @@ struct U4Solid
 
     static int          Type(const char* entityType ) ;
     static const char*  Tag( int type ) ;
+    static bool         ContainsTessellated(const G4VSolid* solid) ;
     const char* tag() const ;
 
 
@@ -346,6 +347,35 @@ inline const char* U4Solid::Tag(int type)   // static
             break;
         }
     return tag ;
+}
+
+/**
+ * Returns true when a solid or one of its constituents is tessellated.
+ *
+ * Boolean operands, displaced solids, and multi-union members are searched
+ * recursively. `U4Tree` uses this result to triangulate the enclosing
+ * logical-volume solid.
+ */
+
+inline bool U4Solid::ContainsTessellated(const G4VSolid* solid) // static
+{
+    if (solid == nullptr) return false;
+    if (dynamic_cast<const G4TessellatedSolid*>(solid) != nullptr) return true;
+
+    const G4DisplacedSolid* displaced = dynamic_cast<const G4DisplacedSolid*>(solid);
+    if (displaced != nullptr) return ContainsTessellated(displaced->GetConstituentMovedSolid());
+
+    const G4BooleanSolid* boolean = dynamic_cast<const G4BooleanSolid*>(solid);
+    if (boolean != nullptr)
+        return ContainsTessellated(boolean->GetConstituentSolid(0)) ||
+               ContainsTessellated(boolean->GetConstituentSolid(1));
+
+    const G4MultiUnion* multi_union = dynamic_cast<const G4MultiUnion*>(solid);
+    if (multi_union != nullptr)
+        for (int i = 0; i < multi_union->GetNumberOfSolids(); ++i)
+            if (ContainsTessellated(multi_union->GetSolid(i))) return true;
+
+    return false;
 }
 
 inline const char* U4Solid::tag() const { return Tag(type) ; }
@@ -925,12 +955,11 @@ inline void U4Solid::init_Trd()
 }
 
 /**
- * Creates an axis-aligned box placeholder for a tessellated solid.
+ * Converts a tessellated solid to an axis-aligned box placeholder.
  *
- * The placeholder preserves the solid's extent and boundary metadata, but not
- * its facets. Configure the solid for triangulation with
- * `stree__force_triangulate_solid`; `U4Mesh` then supplies the exact facets for
- * GPU intersection.
+ * The placeholder preserves the extent and boundary metadata. `U4Tree`
+ * detects tessellated constituents and selects the enclosing logical-volume
+ * solid for triangulation, allowing `U4Mesh` to supply the exact facets.
  */
 
 inline void U4Solid::init_Tessellated()
@@ -953,12 +982,6 @@ inline void U4Solid::init_Tessellated()
         glm::tmat4x4<double> xf = glm::translate(glm::tmat4x4<double>(1.), tla);
         root->combineXF(xf);
     }
-
-    LOG(plog::warning)
-        << "U4Solid::init_Tessellated"
-        << " name " << (name ? name : "-")
-        << " facets " << tess->GetNumberOfFacets()
-        << " : analytic bbox placeholder only, list the solid in stree__force_triangulate_solid";
 }
 
 // Compute 6 outward face planes + AABB from 8 vertices, install as CSG_CONVEXPOLYHEDRON root.

--- a/u4/U4Tree.h
+++ b/u4/U4Tree.h
@@ -737,6 +737,9 @@ inline void U4Tree::initSolid(const G4VSolid* const so, int lvid )
     sn* root = U4Solid::Convert(so, lvid, d );
     assert( root );
 
+    if (U4Solid::ContainsTessellated(so))
+        st->force_triangulate_lvid.push_back(lvid);
+
     solids.push_back(so);
     st->soname_raw.push_back(name);
     st->solids.push_back(root);

--- a/u4/tests/CMakeLists.txt
+++ b/u4/tests/CMakeLists.txt
@@ -62,6 +62,7 @@ set(TEST_SOURCES
    U4PhysicsTableTest.cc 
 
    SpherePhiCutQuarterShellTest.cc
+   TessellatedSolidTest.cc
    TubePhiCutQuarterShellTest.cc
 )
 

--- a/u4/tests/CMakeLists.txt
+++ b/u4/tests/CMakeLists.txt
@@ -63,6 +63,7 @@ set(TEST_SOURCES
 
    SpherePhiCutQuarterShellTest.cc
    TessellatedSolidTest.cc
+   U4TreeTessellatedTest.cc
    TubePhiCutQuarterShellTest.cc
 )
 

--- a/u4/tests/TessellatedSolidTest.cc
+++ b/u4/tests/TessellatedSolidTest.cc
@@ -1,0 +1,97 @@
+/**
+ * Verifies host-side conversion of a `G4TessellatedSolid` by `U4Solid`.
+ *
+ * This test constructs a closed, offset tetrahedron at runtime. It checks the
+ * entity-type and tag dispatch, then verifies that conversion produces a box
+ * placeholder with the expected dimensions, local bounds, and translation.
+ *
+ * This test does not exercise triangulated GPU intersection.
+ */
+
+#include <cmath>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "G4TessellatedSolid.hh"
+#include "G4TriangularFacet.hh"
+
+#include "U4Solid.h"
+
+#include "s_csg.h"
+
+namespace
+{
+bool close(double actual, double expected, double tolerance = 1.e-9)
+{
+    return std::fabs(actual - expected) <= tolerance * (1. + std::fabs(expected));
+}
+
+bool addFacet(G4TessellatedSolid& solid, const G4ThreeVector& a, const G4ThreeVector& b, const G4ThreeVector& c)
+{
+    return solid.AddFacet(new G4TriangularFacet(a, b, c, ABSOLUTE));
+}
+} // namespace
+
+int main()
+{
+    const G4ThreeVector p0(10., 20., 30.);
+    const G4ThreeVector p1(14., 20., 30.);
+    const G4ThreeVector p2(10., 26., 30.);
+    const G4ThreeVector p3(10., 20., 38.);
+
+    G4TessellatedSolid solid("OffsetTetrahedron");
+
+    bool facetsAdded =
+        addFacet(solid, p0, p2, p1) &&
+        addFacet(solid, p0, p1, p3) &&
+        addFacet(solid, p0, p3, p2) &&
+        addFacet(solid, p1, p2, p3);
+    if (!facetsAdded)
+    {
+        std::cerr << "failed to construct tessellated test geometry" << std::endl;
+        return EXIT_FAILURE;
+    }
+    solid.SetSolidClosed(true);
+
+    if (U4Solid::Type(solid.GetEntityType().c_str()) != _G4TessellatedSolid ||
+        std::string(U4Solid::Tag(_G4TessellatedSolid)) != "Tes")
+    {
+        std::cerr << "G4TessellatedSolid type or tag dispatch failed" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    s_csg csg;
+    sn*   root = U4Solid::Convert(&solid, 0, 0, 0);
+    if (root == nullptr || root->typecode != CSG_BOX3)
+    {
+        std::cerr << "G4TessellatedSolid did not convert to a box placeholder" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    const double*        param = root->getParam();
+    const double*        aabb = root->getAABB();
+    glm::tmat4x4<double> transform(1.);
+    glm::tmat4x4<double> inverse(1.);
+    root->getNodeTransformProduct(transform, inverse, false, nullptr, nullptr);
+
+    bool dimensions =
+        param != nullptr && close(param[0], 4.) && close(param[1], 6.) && close(param[2], 8.);
+    bool localBounds =
+        aabb != nullptr &&
+        close(aabb[0], -2.) && close(aabb[1], -3.) && close(aabb[2], -4.) &&
+        close(aabb[3], 2.) && close(aabb[4], 3.) && close(aabb[5], 4.);
+    bool translation =
+        close(transform[3][0], 12.) && close(transform[3][1], 23.) && close(transform[3][2], 34.);
+
+    delete root;
+
+    if (!dimensions || !localBounds || !translation)
+    {
+        std::cerr << "box placeholder does not preserve the tessellated-solid extent" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "G4TessellatedSolid converted to the expected translated box placeholder" << std::endl;
+    return EXIT_SUCCESS;
+}

--- a/u4/tests/TessellatedSolidTest.cc
+++ b/u4/tests/TessellatedSolidTest.cc
@@ -1,11 +1,16 @@
 /**
- * Verifies host-side conversion of a `G4TessellatedSolid` by `U4Solid`.
+ * @file TessellatedSolidTest.cc
+ * @brief Verifies host-side tessellated-solid conversion and detection.
  *
- * This test constructs a closed, offset tetrahedron at runtime. It checks the
- * entity-type and tag dispatch, then verifies that conversion produces a box
+ * The test constructs a closed, offset tetrahedron at runtime. It verifies
+ * entity-type and tag dispatch, then checks that conversion produces a box
  * placeholder with the expected dimensions, local bounds, and translation.
  *
- * This test does not exercise triangulated GPU intersection.
+ * It also verifies recursive detection when the tetrahedron is used directly
+ * or inside Boolean, displaced, and multi-union solids, while confirming that
+ * an ordinary box is not detected as tessellated.
+ *
+ * The test does not exercise triangulated GPU intersection.
  */
 
 #include <cmath>
@@ -13,8 +18,13 @@
 #include <iostream>
 #include <string>
 
+#include "G4Box.hh"
+#include "G4DisplacedSolid.hh"
+#include "G4MultiUnion.hh"
 #include "G4TessellatedSolid.hh"
+#include "G4Transform3D.hh"
 #include "G4TriangularFacet.hh"
+#include "G4UnionSolid.hh"
 
 #include "U4Solid.h"
 
@@ -58,6 +68,26 @@ int main()
         std::string(U4Solid::Tag(_G4TessellatedSolid)) != "Tes")
     {
         std::cerr << "G4TessellatedSolid type or tag dispatch failed" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    G4Box box("Box", 1., 1., 1.);
+    G4UnionSolid boolean("BooleanWithTessellated", &box, &solid);
+    G4DisplacedSolid displaced("DisplacedTessellated", &solid, G4Transform3D());
+    G4MultiUnion multiUnion("MultiUnionWithTessellated");
+    multiUnion.AddNode(box, G4Transform3D());
+    multiUnion.AddNode(solid, G4Transform3D());
+
+    bool containment =
+        U4Solid::ContainsTessellated(&solid) &&
+        U4Solid::ContainsTessellated(&boolean) &&
+        U4Solid::ContainsTessellated(&displaced) &&
+        U4Solid::ContainsTessellated(&multiUnion) &&
+        !U4Solid::ContainsTessellated(&box);
+
+    if (!containment)
+    {
+        std::cerr << "recursive tessellated-solid detection failed" << std::endl;
         return EXIT_FAILURE;
     }
 

--- a/u4/tests/TessellatedSolidTest.cc
+++ b/u4/tests/TessellatedSolidTest.cc
@@ -71,10 +71,10 @@ int main()
         return EXIT_FAILURE;
     }
 
-    G4Box box("Box", 1., 1., 1.);
-    G4UnionSolid boolean("BooleanWithTessellated", &box, &solid);
+    G4Box            box("Box", 1., 1., 1.);
+    G4UnionSolid     boolean("BooleanWithTessellated", &box, &solid);
     G4DisplacedSolid displaced("DisplacedTessellated", &solid, G4Transform3D());
-    G4MultiUnion multiUnion("MultiUnionWithTessellated");
+    G4MultiUnion     multiUnion("MultiUnionWithTessellated");
     multiUnion.AddNode(box, G4Transform3D());
     multiUnion.AddNode(solid, G4Transform3D());
 

--- a/u4/tests/TessellatedSolidTest.cc
+++ b/u4/tests/TessellatedSolidTest.cc
@@ -6,8 +6,10 @@
  * entity-type and tag dispatch, then checks that conversion produces a box
  * placeholder with the expected dimensions, local bounds, and translation.
  *
- * It also verifies recursive detection when the tetrahedron is used directly
- * or inside Boolean, displaced, and multi-union solids, while confirming that
+ * The test places the tetrahedron with a non-identity rotation and verifies
+ * that displaced-solid and multi-union transforms preserve it. Recursive
+ * detection is checked when the tetrahedron is used directly or inside
+ * Boolean, displaced, and multi-union solids, while confirming that
  * an ordinary box is not detected as tessellated.
  *
  * The test does not exercise triangulated GPU intersection.
@@ -21,6 +23,7 @@
 #include "G4Box.hh"
 #include "G4DisplacedSolid.hh"
 #include "G4MultiUnion.hh"
+#include "G4RotationMatrix.hh"
 #include "G4TessellatedSolid.hh"
 #include "G4Transform3D.hh"
 #include "G4TriangularFacet.hh"
@@ -35,6 +38,19 @@ namespace
 bool close(double actual, double expected, double tolerance = 1.e-9)
 {
     return std::fabs(actual - expected) <= tolerance * (1. + std::fabs(expected));
+}
+
+bool close(const glm::tmat4x4<double>& actual, const glm::tmat4x4<double>& expected)
+{
+    for (int column = 0; column < 4; ++column)
+    {
+        for (int row = 0; row < 4; ++row)
+        {
+            if (!close(actual[column][row], expected[column][row]))
+                return false;
+        }
+    }
+    return true;
 }
 
 bool addFacet(G4TessellatedSolid& solid, const G4ThreeVector& a, const G4ThreeVector& b, const G4ThreeVector& c)
@@ -122,6 +138,58 @@ int main()
         return EXIT_FAILURE;
     }
 
-    std::cout << "G4TessellatedSolid converted to the expected translated box placeholder" << std::endl;
+    G4RotationMatrix rotation;
+    rotation.rotateZ(0.5 * std::acos(-1.));
+    G4Transform3D placement(rotation, G4ThreeVector(100., 200., 300.));
+
+    G4DisplacedSolid rotatedDisplaced("RotatedDisplacedTessellated", &solid, placement);
+    G4MultiUnion     rotatedMultiUnion("RotatedMultiUnionTessellated");
+    rotatedMultiUnion.AddNode(solid, placement);
+
+    sn* displacedRoot = U4Solid::Convert(&rotatedDisplaced, 1, 0, 0);
+    sn* multiUnionRoot = U4Solid::Convert(&rotatedMultiUnion, 2, 0, 0);
+
+    if (displacedRoot == nullptr || multiUnionRoot == nullptr || multiUnionRoot->num_child() != 1)
+    {
+        std::cerr << "failed to convert rotated tessellated test geometry" << std::endl;
+        delete displacedRoot;
+        delete multiUnionRoot;
+        return EXIT_FAILURE;
+    }
+
+    glm::tmat4x4<double> displacedPlacement(1.);
+    glm::tmat4x4<double> multiUnionPlacement(1.);
+    U4Transform::GetDispTransform(displacedPlacement, &rotatedDisplaced);
+    U4Transform::GetMultiUnionItemTransform(multiUnionPlacement, &rotatedMultiUnion, 0);
+
+    glm::tmat4x4<double> displacedTransform(1.);
+    glm::tmat4x4<double> displacedInverse(1.);
+    displacedRoot->getNodeTransformProduct(
+        displacedTransform, displacedInverse, false, nullptr, nullptr);
+
+    glm::tmat4x4<double> multiUnionTransform(1.);
+    glm::tmat4x4<double> multiUnionInverse(1.);
+    multiUnionRoot->get_child(0)->getNodeTransformProduct(
+        multiUnionTransform, multiUnionInverse, false, nullptr, nullptr);
+
+    glm::tmat4x4<double> expectedDisplaced = displacedPlacement * transform;
+    glm::tmat4x4<double> expectedMultiUnion = multiUnionPlacement * transform;
+    bool                 displacedPlacementPreserved =
+        close(displacedTransform, expectedDisplaced) &&
+        close(displacedInverse, glm::inverse(expectedDisplaced));
+    bool multiUnionPlacementPreserved =
+        close(multiUnionTransform, expectedMultiUnion) &&
+        close(multiUnionInverse, glm::inverse(expectedMultiUnion));
+
+    delete displacedRoot;
+    delete multiUnionRoot;
+
+    if (!displacedPlacementPreserved || !multiUnionPlacementPreserved)
+    {
+        std::cerr << "rotated enclosing placement was composed in the wrong order" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "G4TessellatedSolid conversion preserved extent and rotated placements" << std::endl;
     return EXIT_SUCCESS;
 }

--- a/u4/tests/U4TreeTessellatedTest.cc
+++ b/u4/tests/U4TreeTessellatedTest.cc
@@ -1,0 +1,139 @@
+/**
+ * Verifies U4Tree handling of repeated, nested tessellated solids.
+ *
+ * The test builds a Boolean solid containing a tessellated tetrahedron at
+ * runtime and places its logical volume twice in a simple world. It checks
+ * that U4Tree selects the enclosing Boolean solid for triangulation, keeps
+ * both placements out of analytic repeat factors, and records both as global
+ * triangulated nodes. This is a CPU-side geometry-conversion test; it does not
+ * run GPU intersection.
+ */
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+
+#include "G4Box.hh"
+#include "G4LogicalVolume.hh"
+#include "G4PVPlacement.hh"
+#include "G4TessellatedSolid.hh"
+#include "G4TriangularFacet.hh"
+#include "G4UnionSolid.hh"
+
+#include "OPTICKS_LOG.hh"
+#include "U4Material.hh"
+#include "U4Tree.h"
+
+#include "NPFold.h"
+#include "stree.h"
+
+namespace
+{
+bool addFacet(G4TessellatedSolid& solid, const G4ThreeVector& a, const G4ThreeVector& b, const G4ThreeVector& c)
+{
+    return solid.AddFacet(new G4TriangularFacet(a, b, c, ABSOLUTE));
+}
+
+G4TessellatedSolid* makeTetrahedron()
+{
+    G4ThreeVector p0(0., 0., 0.);
+    G4ThreeVector p1(4., 0., 0.);
+    G4ThreeVector p2(0., 4., 0.);
+    G4ThreeVector p3(0., 0., 4.);
+
+    G4TessellatedSolid* solid = new G4TessellatedSolid("NestedTetrahedron");
+    bool facetsAdded =
+        addFacet(*solid, p0, p2, p1) &&
+        addFacet(*solid, p0, p1, p3) &&
+        addFacet(*solid, p0, p3, p2) &&
+        addFacet(*solid, p1, p2, p3);
+
+    if (!facetsAdded) return nullptr;
+    solid->SetSolidClosed(true);
+    return solid;
+}
+
+int findLvid(const stree& st, const char* name)
+{
+    std::vector<std::string>::const_iterator it = std::find(st.soname.begin(), st.soname.end(), name);
+    return it == st.soname.end() ? -1 : int(std::distance(st.soname.begin(), it));
+}
+} // namespace
+
+int main(int argc, char** argv)
+{
+    OPTICKS_LOG(argc, argv);
+
+    G4TessellatedSolid* tessellated = makeTetrahedron();
+    if (tessellated == nullptr)
+    {
+        std::cerr << "failed to construct tessellated test geometry" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    G4Material* material = U4Material::Get(U4Material::VACUUM);
+    if (material == nullptr)
+    {
+        std::cerr << "failed to construct vacuum material" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    G4Box* component = new G4Box("BooleanBox", 3., 3., 3.);
+    G4UnionSolid* nested = new G4UnionSolid("NestedTessellatedUnion", component, tessellated);
+    G4LogicalVolume* nestedLV = new G4LogicalVolume(nested, material, "NestedTessellatedLV");
+
+    G4Box* worldSolid = new G4Box("WorldBox", 100., 100., 100.);
+    G4LogicalVolume* worldLV = new G4LogicalVolume(worldSolid, material, "WorldLV");
+
+    new G4PVPlacement(nullptr, G4ThreeVector(-20., 0., 0.), nestedLV, "NestedPV0", worldLV, false, 0);
+    new G4PVPlacement(nullptr, G4ThreeVector( 20., 0., 0.), nestedLV, "NestedPV1", worldLV, false, 1);
+    G4VPhysicalVolume* world = new G4PVPlacement(
+        nullptr, G4ThreeVector(), worldLV, "WorldPV", nullptr, false, 0);
+
+    stree st;
+    st.FREQ_CUT = 2;
+    U4Tree* tree = U4Tree::Create(&st, world);
+    if (tree == nullptr)
+    {
+        std::cerr << "U4Tree creation failed" << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    int lvid = findLvid(st, "NestedTessellatedUnion");
+    std::vector<int> nodes;
+    if (lvid > -1) st.find_lvid_nodes(nodes, lvid, 'N');
+
+    bool nodesAreGlobal = nodes.size() == 2;
+    for (unsigned i = 0; i < nodes.size(); ++i)
+        nodesAreGlobal = nodesAreGlobal && st.nds[nodes[i]].repeat_index == 0;
+
+    int triangulatedPlacements = 0;
+    for (unsigned i = 0; i < st.tri.size(); ++i)
+        if (st.tri[i].lvid == lvid) triangulatedPlacements += 1;
+
+    const NPFold* mesh = lvid > -1 ? st.mesh->get_subfold(st.soname[lvid].c_str()) : nullptr;
+    bool passed =
+        lvid > -1 &&
+        st.is_force_triangulate(lvid) &&
+        st.get_num_factor() == 0 &&
+        nodesAreGlobal &&
+        triangulatedPlacements == 2 &&
+        mesh != nullptr &&
+        mesh->get_meta<int>("lvid", -1) == lvid;
+
+    if (!passed)
+    {
+        std::cerr
+            << "nested tessellated solid was not retained as global triangulated geometry"
+            << " lvid " << lvid
+            << " factors " << st.get_num_factor()
+            << " nodes " << nodes.size()
+            << " triangulated placements " << triangulatedPlacements
+            << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "repeated nested tessellated solid remained global and triangulated" << std::endl;
+    return EXIT_SUCCESS;
+}

--- a/u4/tests/U4TreeTessellatedTest.cc
+++ b/u4/tests/U4TreeTessellatedTest.cc
@@ -43,13 +43,14 @@ G4TessellatedSolid* makeTetrahedron()
     G4ThreeVector p3(0., 0., 4.);
 
     G4TessellatedSolid* solid = new G4TessellatedSolid("NestedTetrahedron");
-    bool facetsAdded =
+    bool                facetsAdded =
         addFacet(*solid, p0, p2, p1) &&
         addFacet(*solid, p0, p1, p3) &&
         addFacet(*solid, p0, p3, p2) &&
         addFacet(*solid, p1, p2, p3);
 
-    if (!facetsAdded) return nullptr;
+    if (!facetsAdded)
+        return nullptr;
     solid->SetSolidClosed(true);
     return solid;
 }
@@ -79,15 +80,15 @@ int main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    G4Box* component = new G4Box("BooleanBox", 3., 3., 3.);
-    G4UnionSolid* nested = new G4UnionSolid("NestedTessellatedUnion", component, tessellated);
+    G4Box*           component = new G4Box("BooleanBox", 3., 3., 3.);
+    G4UnionSolid*    nested = new G4UnionSolid("NestedTessellatedUnion", component, tessellated);
     G4LogicalVolume* nestedLV = new G4LogicalVolume(nested, material, "NestedTessellatedLV");
 
-    G4Box* worldSolid = new G4Box("WorldBox", 100., 100., 100.);
+    G4Box*           worldSolid = new G4Box("WorldBox", 100., 100., 100.);
     G4LogicalVolume* worldLV = new G4LogicalVolume(worldSolid, material, "WorldLV");
 
     new G4PVPlacement(nullptr, G4ThreeVector(-20., 0., 0.), nestedLV, "NestedPV0", worldLV, false, 0);
-    new G4PVPlacement(nullptr, G4ThreeVector( 20., 0., 0.), nestedLV, "NestedPV1", worldLV, false, 1);
+    new G4PVPlacement(nullptr, G4ThreeVector(20., 0., 0.), nestedLV, "NestedPV1", worldLV, false, 1);
     G4VPhysicalVolume* world = new G4PVPlacement(
         nullptr, G4ThreeVector(), worldLV, "WorldPV", nullptr, false, 0);
 
@@ -100,9 +101,10 @@ int main(int argc, char** argv)
         return EXIT_FAILURE;
     }
 
-    int lvid = findLvid(st, "NestedTessellatedUnion");
+    int              lvid = findLvid(st, "NestedTessellatedUnion");
     std::vector<int> nodes;
-    if (lvid > -1) st.find_lvid_nodes(nodes, lvid, 'N');
+    if (lvid > -1)
+        st.find_lvid_nodes(nodes, lvid, 'N');
 
     bool nodesAreGlobal = nodes.size() == 2;
     for (unsigned i = 0; i < nodes.size(); ++i)
@@ -110,10 +112,11 @@ int main(int argc, char** argv)
 
     int triangulatedPlacements = 0;
     for (unsigned i = 0; i < st.tri.size(); ++i)
-        if (st.tri[i].lvid == lvid) triangulatedPlacements += 1;
+        if (st.tri[i].lvid == lvid)
+            triangulatedPlacements += 1;
 
     const NPFold* mesh = lvid > -1 ? st.mesh->get_subfold(st.soname[lvid].c_str()) : nullptr;
-    bool passed =
+    bool          passed =
         lvid > -1 &&
         st.is_force_triangulate(lvid) &&
         st.get_num_factor() == 0 &&


### PR DESCRIPTION
Add host-side `G4TessellatedSolid` handling so tessellated geometry can pass through Geant4-to-CSG conversion and automatically use the existing triangulated-mesh path.

Implementation:
- recognize `G4TessellatedSolid` in entity-type and tag dispatch
- create a translated `CSG_BOX3` placeholder from the Geant4 minimum and maximum extents while `U4Mesh` supplies the exact facets
- recursively detect tessellated constituents inside Boolean, displaced, and multi-union solids and select the enclosing logical-volume solid for triangulation
- exclude repeated subtrees containing triangulated solids from analytic factorization so their placements remain in global triangle geometry
- compose displaced-solid and multi-union placements before the placeholder's centering transform, preserving rotated offset tessellations
- document automatic native-tessellation handling and the manual `stree__force_triangulate_solid` option for other solids

Test coverage:
- construct closed tessellated tetrahedra at runtime instead of adding a GDML fixture
- verify entity-type and tag dispatch, placeholder dimensions, local bounds, and center translation
- verify recursive detection and rotated placement composition for displaced and multi-union solids
- verify `U4Tree` automatically selects nested tessellated geometry and keeps repeated placements out of analytic factors
- keep GPU facet intersection outside the scope of these host-side unit tests

## Acknowledgements

This PR builds on the initial `G4TessellatedSolid` conversion developed by Gabor Galgoczi in [`5e1e6bbc`](https://github.com/BNLNPPS/simphony/commit/5e1e6bbc3313218342cb5d95805fa9095f497910). It extends that work with automatic triangulation selection for native and nested tessellated solids, repeated-volume handling, rotated-placement correctness, CI coverage, and user documentation.

Co-authored-by: Gabor Galgoczi <gaborgalgoczi@gmail.com>
